### PR TITLE
add commits to visited when iterating through history

### DIFF
--- a/git-s3-push.go
+++ b/git-s3-push.go
@@ -199,8 +199,10 @@ func (repo *Repository) FindUnpushedModifiedFiles() error {
 
 		for i := 0; i < currentCommit.ParentCount(); i++ {
 			parentCommit := currentCommit.Parent(i)
-			if !visited.Contains(parentCommit) {
+			cid := parentCommit.Id().String()
+			if !visited.Contains(cid) {
 				queue = append(queue, parentCommit)
+				visited.Add(cid)
 			}
 		}
 


### PR DESCRIPTION
for a never pushed new repo, this would cause infinite loop.